### PR TITLE
us phone and sprint2 scaffolding

### DIFF
--- a/pii_data.py
+++ b/pii_data.py
@@ -8,7 +8,11 @@ class Pii(str):
     # https://regex101.com
     # https://www.w3schools.com/python/python_regex.asp
     def has_us_phone(self):
-        return None
+        # Match a US phone number ddd-ddd-dddd ie 123-456-7890
+        match = re.search(r'\d{3}-\d{3}-\d{4}', self)
+        if match:
+            return True
+        return False
 
     def has_email(self):
         return None
@@ -48,3 +52,12 @@ def read_data(filename: str):
 if __name__ == '__main__':
     data = read_data('sample_data.txt')
     print(data)
+    print('---')
+
+    pii_data = Pii('My phone number is 123-123-1234')
+    print(pii_data)
+
+    if pii_data.has_pii():
+        print('There is PII data preset')
+    else:
+        print('No PII data detected')

--- a/pii_data.py
+++ b/pii_data.py
@@ -1,6 +1,41 @@
 import re
 
 
+# PII = Personally Identifiable Information
+# Create a new Pii class based on str
+class Pii(str):
+    # For help with regex see
+    # https://regex101.com
+    # https://www.w3schools.com/python/python_regex.asp
+    def has_us_phone(self):
+        return None
+
+    def has_email(self):
+        return None
+
+    def has_ipv4(self):
+        return None
+
+    def has_ipv6(self):
+        return None
+
+    def has_name(self):
+        return None
+
+    def has_street_address(self):
+        return None
+
+    def has_credit_card(self):
+        return None
+
+    def has_at_handle(self):
+        return None
+
+    def has_pii(self):
+        return self.has_us_phone() or self.has_email() or self.has_ipv4() or self.has_ipv6() or self.has_name() or \
+               self.has_street_address() or self.has_credit_card() or self.has_at_handle()
+
+
 def read_data(filename: str):
     data = []
     with open(filename) as f:

--- a/test_pii_data.py
+++ b/test_pii_data.py
@@ -1,5 +1,6 @@
 import unittest
 from pii_data import read_data
+from pii_data import Pii
 
 
 class DataTestCases(unittest.TestCase):
@@ -28,11 +29,46 @@ class DataTestCases(unittest.TestCase):
                          'Aggie Pride',
                          'Aggies are always number 1!',
                          'Because thats what Aggies do']
-                         
 
         data = read_data('sample_data.txt')
 
         self.assertEqual(data, expected_data)
+
+    def test_has_us_phone(self):
+        test_data = Pii()
+        self.assertEqual(test_data.has_us_phone(), None)
+
+    def test_has_email(self):
+        test_data = Pii()
+        self.assertEqual(test_data.has_email(), None)
+
+    def test_has_ipv4(self):
+        test_data = Pii()
+        self.assertEqual(test_data.has_ipv4(), None)
+
+    def test_has_ipv6(self):
+        test_data = Pii()
+        self.assertEqual(test_data.has_ipv6(), None)
+
+    def test_has_name(self):
+        test_data = Pii()
+        self.assertEqual(test_data.has_name(), None)
+
+    def test_has_street_address(self):
+        test_data = Pii()
+        self.assertEqual(test_data.has_street_address(), None)
+
+    def test_has_credit_card(self):
+        test_data = Pii()
+        self.assertEqual(test_data.has_credit_card(), None)
+
+    def test_has_at_handle(self):
+        test_data = Pii()
+        self.assertEqual(test_data.has_at_handle(), None)
+
+    def test_has_pii(self):
+        test_data = Pii()
+        self.assertEqual(test_data.has_pii(), None)
 
 
 if __name__ == '__main__':

--- a/test_pii_data.py
+++ b/test_pii_data.py
@@ -35,8 +35,18 @@ class DataTestCases(unittest.TestCase):
         self.assertEqual(data, expected_data)
 
     def test_has_us_phone(self):
-        test_data = Pii()
-        self.assertEqual(test_data.has_us_phone(), None)
+        # Test a valid US phone number
+        test_data = Pii('My phone number is 970-555-1212')
+        self.assertTrue(test_data.has_us_phone())
+
+        # Test a partial US phone number
+        test_data = Pii('My number is 555-1212')
+        self.assertFalse(test_data.has_us_phone())
+
+        # Test a phone number with incorrect delimiters
+        # TODO discuss changing requirements to support this
+        test_data = Pii('My phone number is 970.555.1212')
+        self.assertFalse(test_data.has_us_phone())
 
     def test_has_email(self):
         test_data = Pii()


### PR DESCRIPTION
This closes #56 

Added a us phone example and the scaffolding required. 

Initial requirement for us_phone is to match ddd-ddd-dddd