### PR TITLE
S3 street address

### DIFF
--- a/pii_data.py
+++ b/pii_data.py
@@ -7,6 +7,7 @@ class Pii(str):
     # For help with regex see
     # https://regex101.com
     # https://www.w3schools.com/python/python_regex.asp
+
     def has_us_phone(self):
         if re.search(r'\d{9}', self):
             return True
@@ -49,11 +50,15 @@ class Pii(str):
             return True
         return False
 
-    def has_street_address(self):
-        match = re.search(r'^\d{0,4}\s[A-Z][a-zA-Z]{2,30}\s\b(Ave|St|Blvd|Rd)\b', self)
-        if match:
-            return True
-        return False
+    def has_street_address(self, anonymize=False):
+        newstr, count1 = re.subn(r'(?<=\s)\d{0,4}\s[A-Z][a-zA-Z]{2,30}\s\b(Ave|St|Blvd|Rd)\b', '[Street Address]', self)
+        print(newstr)
+        print(bool(count1))
+
+        if anonymize:
+            return newstr
+        else:
+            return bool(count1)
 
     def has_credit_card(self):
         match = re.search(r'\d{4}-\d{4}-\d{4}-\d{4}', self)

--- a/test_pii_data.py
+++ b/test_pii_data.py
@@ -37,7 +37,6 @@ class DataTestCases(unittest.TestCase):
         data = read_data('sample_data.txt')
 
         self.assertEqual(data, expected_data)
-
     def test_has_us_phone(self):
         # Test a valid US phone number
         test_data = Pii('My phone number is 970-555-1212')
@@ -118,19 +117,29 @@ class DataTestCases(unittest.TestCase):
         self.assertEqual(test_data.has_name(), False)
 
 
+    def test_anonymize_has_street_address(self):
+        self.assertEqual(Pii('My Street Address is 123 Ocho St').has_street_address(anonymize=True),
+                         'My Street Address is [Street Address]')
+
+        self.assertEqual(Pii('My Sean Tisdale and I stay at is 989 Block Blvd').has_street_address(anonymize=True),
+                         'My Sean Tisdale and I stay at is [Street Address]')
+
+        self.assertEqual(Pii('77989 Block Blvd is invalid').has_street_address(anonymize=True),
+                         '77989 Block Blvd is invalid')
+
     def test_has_street_address(self):
-        test_data = Pii('123 Addy Rd')
+        test_data = Pii(' 123 Addy Rd')
         self.assertEqual(test_data.has_street_address(), True)
 
-        test_data = Pii('12356 Michellen Rd')
+        test_data = Pii(' 12356 Michellen Rd')
         self.assertEqual(test_data.has_street_address(), False)
          
-        test_data = Pii('123 pope Blvd')
+        test_data = Pii(' 123 pope Blvd')
         self.assertEqual(test_data.has_street_address(), False)
 
-        test_data = Pii('123 Rich Blvd')
+        test_data = Pii(' 123 Rich Blvd')
         self.assertEqual(test_data.has_street_address(), True)
-
+        
     def test_has_credit_card(self):
         test_data = Pii('My card is 1234-1234-1234-1234')
         self.assertTrue(test_data.has_credit_card())


### PR DESCRIPTION
Completed anonymization for street addresses. The test cases from sprint 1 have been changed to include a space before the address. 
EX: instead of "123 Man Dr" we have " 123 Man Dr